### PR TITLE
bump upstream v2.1.2 and fix license typo

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v2.0.1",
+  "upstreamVersion": "v2.1.2",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "sigp/lighthouse",
   "shortDescription": "Lighthouse is an Ethereum 2.0 client",
@@ -21,5 +21,5 @@
     "homepage": "https://lighthouse-book.sigmaprime.io",
     "readme": "https://github.com/sigp/lighthouse/blob/stable/README.md"
   },
-  "license": "GLP-3.0"
+  "license": "GPL-3.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon
       args:
-        UPSTREAM_VERSION: v2.0.1
+        UPSTREAM_VERSION: v2.1.2
     volumes:
       - "beacon-data:/root/.lighthouse"
     ports:


### PR DESCRIPTION
bump upstream to v2.1.2 and fix license typo from GLP to GPL