### PR TITLE
use standard 3500 beacon port api

### DIFF
--- a/beacon/entrypoint.sh
+++ b/beacon/entrypoint.sh
@@ -8,7 +8,7 @@ exec lighthouse \
     --eth1 --eth1-endpoints $HTTP_WEB3PROVIDER \
     --http \
     --http-address 0.0.0.0 \
-    --http-port 5052 \
+    --http-port $BEACON_API_PORT \
     --port 9000 \
     --metrics \
     --metrics-address 0.0.0.0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,10 @@ services:
     volumes:
       - "beacon-data:/root/.lighthouse"
     ports:
-      - 5052/tcp
-      - 5053/tcp
-      - 5054/tcp
       - "9000"
     restart: unless-stopped
     environment:
+      BEACON_API_PORT: "3500" # Do not change! standard port 3500 for beacon api
       HTTP_WEB3PROVIDER: "http://goerli-geth.dappnode:8545"
       CORSDOMAIN: "http://lighthouse.dappnode"
       CHECKPOINT_SYNC_URL: "http://beacon-chain.prysm-prater.dappnode:4000"
@@ -28,13 +26,11 @@ services:
     volumes:
       - "validator-data:/root/.lighthouse"
       - "validator-public-keys:/root/public-keys"
-    ports:
-      - 5064/tcp
     restart: unless-stopped
     environment:
       PUBLIC_KEYS_FILE: /root/public-keys/public_keys.txt
       HTTP_WEB3SIGNER: "http://web3signer.web3signer-prater.dappnode:9000"
-      BEACON_NODE_ADDR: "http://beacon.lighthouse.dappnode:5052"
+      BEACON_NODE_ADDR: "http://beacon.lighthouse.dappnode:3500" # Do not change! standard port 3500 for beacon api
       GRAFFITI: validating_from_DAppNode
       DEFAULT_VALIDATOR_PUBLIC_KEY: ""
       EXTRA_OPTS: ""


### PR DESCRIPTION
standarize beacon API port to 3500. Used by the dappmanager to get sync status