### PR TITLE
Update homepage link

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -22,7 +22,7 @@
   },
   "links": {
     "ui": "http://ui.web3signer-prater.dappnode?signer_url=http://web3signer.web3signer-prater.dappnode:9000",
-    "homepage": "https://lighthouse-book.sigmaprime.io",
+    "homepage": "https://github.com/dappnode/DAppNodePackage-lighthouse-prater#readme",
     "readme": "https://github.com/sigp/lighthouse/blob/stable/README.md",
     "docs": "https://lighthouse-book.sigmaprime.io/"
   },


### PR DESCRIPTION




This PR removes a redundant link (which was specified for both the docs link and homepage link) Many other packages have the homepage link pointed back to the dpapnode maintained repo for the package, here are some examples:
https://github.com/dappnode/DAppNodePackage-goerli-geth/blob/master/dappnode_package.json#L20
https://github.com/dappnode/DAppNodePackage-ropsten/blob/master/dappnode_package.json#L18

Although, I do see this is a bit inconsistent across packages, with some using the readme link instead  pointed back to the dappnode repo for the package.