### PR TITLE
Implement-fee-recipient-address

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -27,3 +27,14 @@ fields:
       To get Lighthouse up and running in only a few minutes, you can start Lighthouse from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features.  Be sure you are using a trusted node for the fast sync. Check [Lighthouse docs](https://lighthouse-book.sigmaprime.io/checkpoint-sync.html).
       Get your checkpoint sync from [infura](https://infura.io/) (i.e https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX@eth2-beacon-prater.infura.io)
     required: false
+  - id: feeRecipientAddress
+    target:
+      type: environment
+      name: FEE_RECIPIENT_ADDRESS
+      service: validator
+    title: Fee Recipient Address
+    description: >-
+      Fee Recipient is a feature that lets you specify a priority fee recipient address on your validator client instance and beacon node. After The Merge, execution clients will begin depositing priority fees into this address whenever your validator client proposes a new block.
+    required: true
+    pattern: "^0x[a-fA-F0-9]{40}$"
+    patternErrorMessage: Must be a valid address (0x1fd16a...)

--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -63,4 +63,5 @@ exec -c lighthouse \
     --metrics-address 0.0.0.0 \
     --metrics-port 8008 \
     --metrics-allow-origin "*" \
+    --suggested-fee-recipient="${FEE_RECIPIENT_ADDRESS}" \
     $EXTRA_OPTS


### PR DESCRIPTION
Implement fee recipient address during installation through the setup-wizard

For consistency, this value should be set in both services: beacon-chain and validator. See https://github.com/dappnode/DAppNodeSDK/issues/238

Docs: https://lighthouse-book.sigmaprime.io/suggested-fee-recipient.html