### PR TITLE
Bump to `v4.6.0-rc.0`

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse-prater.dnp.dappnode.eth",
   "version": "0.1.20",
-  "upstreamVersion": "v4.5.0",
+  "upstreamVersion": "v4.6.0-rc.0",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "sigp/lighthouse",
   "shortDescription": "Lighthouse Prater Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v4.5.0
+        UPSTREAM_VERSION: v4.6.0-rc.0
     volumes:
       - "beacon-data:/root/.lighthouse"
     ports:
@@ -27,7 +27,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v4.5.0
+        UPSTREAM_VERSION: v4.6.0-rc.0
     restart: unless-stopped
     security_opt:
       - "seccomp:unconfined"


### PR DESCRIPTION
Bump to `v4.6.0-rc.0` to support new Goerli hard fork